### PR TITLE
Require a prompt

### DIFF
--- a/src/AiCommand.php
+++ b/src/AiCommand.php
@@ -2,10 +2,10 @@
 
 namespace WP_CLI\AiCommand;
 
+use WP_CLI;
 use WP_CLI\AiCommand\ToolRepository\CollectionToolRepository;
 use WP_CLI\AiCommand\Tools\FileTools;
 use WP_CLI\AiCommand\Tools\URLTools;
-use WP_CLI;
 use WP_CLI_Command;
 use WP_Community_Events;
 use WP_Error;
@@ -56,6 +56,11 @@ class AiCommand extends WP_CLI_Command {
 	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
+
+		if (empty($args) || !is_array($args)) {
+			WP_CLI::error( 'Please supply a prompt. Try "create a post".' );
+		}
+
 		$this->register_tools($this->server);
 		$this->register_resources($this->server);
 


### PR DESCRIPTION
If you run 

```
wp ai
```

without prompt, the package will fail.

This fixes this by failing gracefully with a user error message

Before

```
$ wp ai
Warning: Undefined array key 0 in /var/www/html/ai-command/src/AiCommand.php on line 62
Fatal error: Uncaught TypeError: WP_CLI\AiCommand\MCP\Client::call_ai_service_with_prompt(): Argument #1 ($prompt) must be of type string, null given, called in /var/www/html/ai-command/src/AiCommand.php on line 62 and defined in /var/www/html/ai-command/src/MCP/Client.php:135
Stack trace:
#0 /var/www/html/ai-command/src/AiCommand.php(62): WP_CLI\AiCommand\MCP\Client->call_ai_service_with_prompt(NULL)
#1 /var/www/html/ai-command/ai-command.php(45): WP_CLI\AiCommand\AiCommand->__invoke(Array, Array)
#2 [internal function]: WP_CLI\AiCommand\{closure}(Array, Array)
#3 /var/www/html/ai-command/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(102): call_user_func(Object(Closure), Array, Array)
#4 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#5 /var/www/html/ai-command/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(441): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(464): WP_CLI\Runner->run_command(Array, Array)
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1296): WP_CLI\Runner->run_command_and_exit()
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#10 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#11 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#12 phar:///usr/local/bin/wp/php/boot-phar.php(20): include('phar:///usr/loc...')
#13 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#14 {main}
  thrown in /var/www/html/ai-command/src/MCP/Client.php on line 135
``` 

After:

```
$ wp ai
Error: Please supply a prompt. Try "create a post".
```